### PR TITLE
Fixed issue #12 (Files dragged from Dock incorrect)

### DIFF
--- a/VirusTotal/Extensions/DropInfo.swift
+++ b/VirusTotal/Extensions/DropInfo.swift
@@ -9,14 +9,50 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 extension DropInfo {
-    /// Given an array of UTType, return an array of URL that confirms to the array of UTType
-    func fileURLsConforming(to contentTypes: [UTType]) -> [URL] {
-        NSPasteboard(name: .drag).fileURLs(contentTypes: contentTypes)
+    /// Return dropped file URLs from Finder and other file sources.
+    @MainActor
+    func fileURLs() async -> [URL] {
+        let providers = itemProviders(for: [.fileURL])
+        guard !providers.isEmpty else {
+            return []
+        }
+
+        var urls: [URL] = []
+        for provider in providers {
+            if let url = await provider.fileURL() {
+                urls.append(url)
+            }
+        }
+
+        return urls
     }
 
-    /// Given an array of UTType, return true if any URL matches the content types, return
-    /// false otherwise
-    func hasFileURLsConforming(to contentTypes: [UTType]) -> Bool {
-        !fileURLsConforming(to: contentTypes).isEmpty
+    /// Return true if the drop contains at least one file URL.
+    @MainActor
+    func hasFileURLs() -> Bool {
+        !itemProviders(for: [.fileURL]).isEmpty
+    }
+}
+
+extension NSItemProvider {
+    @MainActor
+    func fileURL() async -> URL? {
+        await withCheckedContinuation { continuation in
+            loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+                let url: URL?
+
+                if let fileURL = item as? URL, fileURL.isFileURL {
+                    url = fileURL
+                } else if let data = item as? Data, let fileURL = URL(dataRepresentation: data, relativeTo: nil), fileURL.isFileURL {
+                    url = fileURL
+                } else if let string = item as? String, let fileURL = URL(string: string), fileURL.isFileURL {
+                    url = fileURL
+                } else {
+                    url = nil
+                }
+
+                continuation.resume(returning: url?.resolvingSymlinksInPath())
+            }
+        }
     }
 }

--- a/VirusTotal/Extensions/NSPasteboard.swift
+++ b/VirusTotal/Extensions/NSPasteboard.swift
@@ -15,9 +15,8 @@ extension NSPasteboard {
             .urlReadingFileURLsOnly: true
         ]
 
-        if !contentTypes.isEmpty {
-            options[.urlReadingContentsConformToTypes] = contentTypes.map(\.identifier)
-        }
+        // Finder and Dock file drags can fail the content-type filter even when they are valid files.
+        // Keep the source restricted to file URLs and let callers validate the resulting URLs.
 
         guard let urls = readObjects(forClasses: [NSURL.self], options: options) as? [URL] else {
             return []

--- a/VirusTotal/Extensions/NSPasteboard.swift
+++ b/VirusTotal/Extensions/NSPasteboard.swift
@@ -6,11 +6,10 @@
 //
 
 import Cocoa
-import UniformTypeIdentifiers
 
 extension NSPasteboard {
     /// Get the file URLs from dragged and dropped files.
-    func fileURLs(contentTypes: [UTType] = []) -> [URL] {
+    func fileURLs() -> [URL] {
         var options: [ReadingOptionKey: Any] = [
             .urlReadingFileURLsOnly: true
         ]

--- a/VirusTotal/Views/FileBatchView/FileBatchView.swift
+++ b/VirusTotal/Views/FileBatchView/FileBatchView.swift
@@ -33,10 +33,9 @@ struct FileBatchView: View {
                     validateDropInfo(dropInfo)
                 },
                 onPerform: { dropInfo in
-                    Task {
-                        _ = await handleDropInfo(dropInfo)
-                    }
-                    return true
+guard validateDropInfo(dropInfo) else { return false }
+Task { _ = await handleDropInfo(dropInfo) }
+return true
                 }
             ))
             .border(isFileDropped ? Color.accentColor : .clear, width: 5)

--- a/VirusTotal/Views/FileBatchView/FileBatchView.swift
+++ b/VirusTotal/Views/FileBatchView/FileBatchView.swift
@@ -33,7 +33,10 @@ struct FileBatchView: View {
                     validateDropInfo(dropInfo)
                 },
                 onPerform: { dropInfo in
-                    handleDropInfo(dropInfo)
+                    Task {
+                        _ = await handleDropInfo(dropInfo)
+                    }
+                    return true
                 }
             ))
             .border(isFileDropped ? Color.accentColor : .clear, width: 5)
@@ -178,12 +181,19 @@ struct FileBatchView: View {
     }
 
     private func validateDropInfo(_ dropInfo: DropInfo) -> Bool {
-        let fileURLs = dropInfo.fileURLsConforming(to: [.data])
-        return !fileURLs.isEmpty
+        return dropInfo.hasFileURLs()
     }
 
-    private func handleDropInfo(_ dropInfo: DropInfo) -> Bool {
-        let fileURLs = dropInfo.fileURLsConforming(to: [.data])
+    private func handleDropInfo(_ dropInfo: DropInfo) async -> Bool {
+        let providers = dropInfo.itemProviders(for: [.fileURL])
+        guard !providers.isEmpty else { return false }
+
+        var fileURLs: [URL] = []
+        for provider in providers {
+            if let url = await provider.fileURL() {
+                fileURLs.append(url)
+            }
+        }
         guard !fileURLs.isEmpty else { return false }
 
         NSApp.activate(ignoringOtherApps: true)

--- a/VirusTotal/Views/FileView/FileView.swift
+++ b/VirusTotal/Views/FileView/FileView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import Alamofire
-import UniformTypeIdentifiers
 import TipKit
 
 struct FileView: View {
@@ -94,7 +93,10 @@ struct FileView: View {
                     validateDropInfo(dropInfo)
                 },
                 onPerform: { dropInfo in
-                    handleDropInfo(dropInfo)
+                    Task {
+                        _ = await handleDropInfo(dropInfo)
+                    }
+                    return true
                 }
             ))
             .border(isFileDropped ? Color.accentColor : .clear, width: 5)
@@ -179,13 +181,25 @@ struct FileView: View {
         guard canDropFile() else {
             return false
         }
-        let fileURLs = dropInfo.fileURLsConforming(to: [.data])
-        return fileURLs.count == 1
+        return dropInfo.hasFileURLs()
     }
 
     /// Given a DropInfo, handle the dropped item with onPerform
-    private func handleDropInfo(_ dropInfo: DropInfo) -> Bool {
-        guard let fileURL = dropInfo.fileURLsConforming(to: [.data]).first else {
+    private func handleDropInfo(_ dropInfo: DropInfo) async -> Bool {
+        let providers = dropInfo.itemProviders(for: [.fileURL])
+        guard !providers.isEmpty else {
+            return false
+        }
+
+        var fileURL: URL?
+        for provider in providers {
+            if let url = await provider.fileURL() {
+                fileURL = url
+                break
+            }
+        }
+
+        guard let fileURL else {
             return false
         }
         NSApp.activate(ignoringOtherApps: true)

--- a/VirusTotal/Views/FileView/FileView.swift
+++ b/VirusTotal/Views/FileView/FileView.swift
@@ -93,10 +93,9 @@ struct FileView: View {
                     validateDropInfo(dropInfo)
                 },
                 onPerform: { dropInfo in
-                    Task {
-                        _ = await handleDropInfo(dropInfo)
-                    }
-                    return true
+guard validateDropInfo(dropInfo) else { return false }
+Task { _ = await handleDropInfo(dropInfo) }
+return true
                 }
             ))
             .border(isFileDropped ? Color.accentColor : .clear, width: 5)

--- a/VirusTotal/Views/MiniMode/MiniFileView.swift
+++ b/VirusTotal/Views/MiniMode/MiniFileView.swift
@@ -145,9 +145,10 @@ return true
         isFileImporterPresent.toggle()
     }
 
-    /// Given a DropInfo, return true if DropInfo is `.data` and is a single item, return false otherwise
+    /// Given a DropInfo, return true if DropInfo contains exactly one item conforming to `.fileURL`, return false otherwise
     private func validateDropInfo(_ dropInfo: DropInfo) -> Bool {
-        return dropInfo.hasFileURLs()
+        let providers = dropInfo.itemProviders(for: [.fileURL])
+        return providers.count == 1
     }
 
     /// Given a DropInfo, handle the dropped item with onPerform

--- a/VirusTotal/Views/MiniMode/MiniFileView.swift
+++ b/VirusTotal/Views/MiniMode/MiniFileView.swift
@@ -63,10 +63,9 @@ struct MiniFileView: View {
                 validateDropInfo(dropInfo)
             },
             onPerform: { dropInfo in
-                Task {
-                    _ = await handleDropInfo(dropInfo)
-                }
-                return true
+guard validateDropInfo(dropInfo) else { return false }
+Task { _ = await handleDropInfo(dropInfo) }
+return true
             }
         ))
         .onChange(of: viewModel.statusMonitor) {

--- a/VirusTotal/Views/MiniMode/MiniFileView.swift
+++ b/VirusTotal/Views/MiniMode/MiniFileView.swift
@@ -63,7 +63,10 @@ struct MiniFileView: View {
                 validateDropInfo(dropInfo)
             },
             onPerform: { dropInfo in
-                handleDropInfo(dropInfo)
+                Task {
+                    _ = await handleDropInfo(dropInfo)
+                }
+                return true
             }
         ))
         .onChange(of: viewModel.statusMonitor) {
@@ -145,13 +148,25 @@ struct MiniFileView: View {
 
     /// Given a DropInfo, return true if DropInfo is `.data` and is a single item, return false otherwise
     private func validateDropInfo(_ dropInfo: DropInfo) -> Bool {
-        let fileURLs = dropInfo.fileURLsConforming(to: [.data])
-        return fileURLs.count == 1
+        return dropInfo.hasFileURLs()
     }
 
     /// Given a DropInfo, handle the dropped item with onPerform
-    private func handleDropInfo(_ dropInfo: DropInfo) -> Bool {
-        guard let fileURL = dropInfo.fileURLsConforming(to: [.data]).first else {
+    private func handleDropInfo(_ dropInfo: DropInfo) async -> Bool {
+        let providers = dropInfo.itemProviders(for: [.fileURL])
+        guard !providers.isEmpty else {
+            return false
+        }
+
+        var fileURL: URL?
+        for provider in providers {
+            if let url = await provider.fileURL() {
+                fileURL = url
+                break
+            }
+        }
+
+        guard let fileURL else {
             return false
         }
         NSApp.activate(ignoringOtherApps: true)


### PR DESCRIPTION
The drop resolution now uses NSIItemProvider instead of trusting the raw drop URL. Dragging from the downloads folder in the dock was sometimes giving an alias or target URL, not the actual file. The drag validation would sometimes filter out valid Finder drags too.